### PR TITLE
Also allow js string and string[] where Strarray is required

### DIFF
--- a/types/nodegit/checkout-options.d.ts
+++ b/types/nodegit/checkout-options.d.ts
@@ -14,7 +14,7 @@ export class CheckoutOptions {
     notifyPayload?: undefined;
     progressCb?: any;
     progressPayload?: undefined;
-    paths?: Strarray;
+    paths?: Strarray | string | string[];
     baseline?: Tree;
     baselineIndex?: Index;
     targetDirectory?: string;

--- a/types/nodegit/diff-options.d.ts
+++ b/types/nodegit/diff-options.d.ts
@@ -4,7 +4,7 @@ export interface DiffOptions {
     version?: number;
     flags?: number;
     ignoreSubmodules?: number;
-    pathspec?: Strarray;
+    pathspec?: Strarray | string | string[];
     notifyCb?: Function;
     contextLines?: number;
     interhunkLines?: number;

--- a/types/nodegit/fetch-options.d.ts
+++ b/types/nodegit/fetch-options.d.ts
@@ -7,7 +7,7 @@ export interface FetchOptions {
     prune?: number;
     updateFetchhead?: number;
     downloadTags?: number;
-    customHeaders?: Strarray;
+    customHeaders?: Strarray | string | string[];
     proxyOpts?: any;
     [key: string]: any;
 }

--- a/types/nodegit/index_.d.ts
+++ b/types/nodegit/index_.d.ts
@@ -26,7 +26,7 @@ export class Index {
     static open(indexPath: string): Promise<Index>;
 
     add(sourceEntry: IndexEntry): number;
-    addAll(pathspec: Strarray, flags: number, callback?: Function): Promise<number>;
+    addAll(pathspec: Strarray | string | string[], flags: number, callback?: Function): Promise<number>;
     addByPath(path: string): Promise<number>;
     caps(): number;
     checksum(): Oid;
@@ -44,11 +44,11 @@ export class Index {
     read(force: number): number;
     readTree(tree: Tree): number;
     remove(path: string, stage: number): number;
-    removeAll(pathspec: Strarray, callback?: Function): Promise<number>;
+    removeAll(pathspec: Strarray | string | string[], callback?: Function): Promise<number>;
     removeByPath(path: string): Promise<number>;
     removeDirectory(dir: string, stage: number): number;
     setCaps(caps: number): number;
-    updateAll(pathspec: Strarray, callback?: Function): Promise<number>;
+    updateAll(pathspec: Strarray | string | string[], callback?: Function): Promise<number>;
     write(): number;
     writeTree(): Promise<Oid>;
     writeTreeTo(repo: Repository): Promise<Oid>;

--- a/types/nodegit/path-spec.d.ts
+++ b/types/nodegit/path-spec.d.ts
@@ -23,7 +23,7 @@ export class Pathspec {
     static matchListEntrycount(m: any): number;
     static matchListFailedEntry(m: any, pos: number): string;
     static matchListFailedEntrycount(m: any): number;
-    static create(pathspec: Strarray): Pathspec;
+    static create(pathspec: Strarray | string | string[]): Pathspec;
 
     free(): void;
     matchDiff(diff: Diff, flags: number): Promise<any>;

--- a/types/nodegit/push-options.d.ts
+++ b/types/nodegit/push-options.d.ts
@@ -6,7 +6,7 @@ export interface PushOptions {
     version?: number;
     pbParallelism?: number;
     callbacks?: RemoteCallbacks;
-    customHeaders?: Strarray;
+    customHeaders?: Strarray | string | string[];
     proxyOpts?: ProxyOptions;
     [key: string]: any;
 }

--- a/types/nodegit/remote.d.ts
+++ b/types/nodegit/remote.d.ts
@@ -62,7 +62,7 @@ export class Remote {
 
     stop(): void;
     updateTips(callbacks: RemoteCallbacks, updateFetchhead: number, downloadTags: number, reflogMessage: string): number;
-    upload(refspecs: Strarray, opts?: PushOptions): number;
+    upload(refspecs: Strarray | string | string[], opts?: PushOptions): number;
     url(): string;
     /**
      * Lists advertised references from a remote. You must connect to the remote before using referenceList.

--- a/types/nodegit/reset.d.ts
+++ b/types/nodegit/reset.d.ts
@@ -20,7 +20,7 @@ export class Reset {
     /**
      * Look up a refs's commit.
      */
-    static default(repo: Repository, target: Object, pathspecs: Strarray): Promise<number>;
+    static default(repo: Repository, target: Object, pathspecs: Strarray | string | string[]): Promise<number>;
     /**
      * Sets the current head to the specified commit oid and optionally resets the index and working tree to match.
      * This behaves like reset but takes an annotated commit, which lets you specify which extended sha syntax string was specified by a user, allowing for more exact reflog messages.

--- a/types/nodegit/status-options.d.ts
+++ b/types/nodegit/status-options.d.ts
@@ -4,6 +4,6 @@ export interface StatusOptions {
     version?: number;
     show?: number;
     flags?: number;
-    pathspec?: Strarray;
+    pathspec?: Strarray | string | string[];
     [key: string]: any;
 }

--- a/types/nodegit/tag.d.ts
+++ b/types/nodegit/tag.d.ts
@@ -10,7 +10,7 @@ export class Tag {
     static createLightweight(repo: Repository, tagName: string, target: Object, force: number): Promise<Oid>;
     static delete(repo: Repository, tagName: string): Promise<number>;
     static list(repo: Repository): Promise<any[]>;
-    static listMatch(tagNames: Strarray, pattern: string, repo: Repository): number;
+    static listMatch(tagNames: Strarray | string | string[], pattern: string, repo: Repository): number;
     /**
      * Retrieves the tag pointed to by the oid
      *

--- a/types/nodegit/transport.d.ts
+++ b/types/nodegit/transport.d.ts
@@ -9,7 +9,7 @@ export namespace Transport {
 }
 
 export class Transport {
-    static sshWithPaths(owner: Remote, payload: Strarray): Promise<Transport>;
+    static sshWithPaths(owner: Remote, payload: Strarray | string | string[]): Promise<Transport>;
     static unregister(prefix: string): number;
     init(version: number): number;
     smartCertificateCheck(cert: Cert, valid: number, hostName: string): number;


### PR DESCRIPTION
Many functions require an argument of the type Git.Strarray, for example 
`static default(repo: Repository, target: Object, pathspecs: Strarray): Promise<number>;`

At the moment it is not possible to generate an instance of Strarray by hand,  `const p = new Strarray()` throws an error and there seems to be no other method to get such an instance.

Since nodegit allows the usage of string and string[] where Strarray is required (see [here](https://github.com/nodegit/nodegit/blob/78765bf811b35c4539f83f3b57d10a9333a7b3a3/test/tests/reset.js#L56), `filePath` is a string), I would also like to allow this in the type definitions.
nodegit seems to automatically convert JS string and string[] to Strarray internally if required.